### PR TITLE
fix: CommonJS build always interpreted as CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "description": "A type-safe string templating library for TypeScript",
   "type": "module",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Node incorrectly interpreted the CommonJS build file as an EcmaScript module because it had a `.js` extension and its closest `package.json` file had `"type": "module"`.

Use `.cjs` and `.mjs` extensions for the built files. This ensures they are always treated as CommonJS and EcmaScript modules respectively.

Closes #53